### PR TITLE
Switch to a non-deprecated mac VM image for CI

### DIFF
--- a/.yamato/build-mac-libraries.yml
+++ b/.yamato/build-mac-libraries.yml
@@ -2,7 +2,7 @@ name: Build QTBase for macOS
   
 agent:
   type: Unity::VM::osx
-  image: buildfarm/mac:stable
+  image: slough-ops/macos-10.14-base
   flavor: m1.mac
 
 artifacts:


### PR DESCRIPTION
This VM image also has higher default values for kern.maxproc and kern.maxprocperuid, which seem to cause build failures when using multiple make threads.

Background: #5.