### PR TITLE
Use more build threads on mac and linux

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -58,11 +58,11 @@ sub makeInstallCommandLine
 	}
 	elsif ($os_name eq 'darwin')
 	{
-		return ("make && make install");
+		return ("make -j`nproc` && make install");
 	}
 	elsif ($os_name eq 'linux')
 	{
-		return ("make && make install");
+		return ("make -j`nproc` && make install");
 	}
 	die ("Unknown platform $os_name");
 }


### PR DESCRIPTION
Make defaults to using a single build thread, even if actions can be run in parallel. Let's use the same number of build threads as CPU vcores on mac and linux, to speed up the build.